### PR TITLE
serve command as default container CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,4 @@ FROM registry.access.redhat.com/ubi8-minimal:8.5
 RUN microdnf update -y && microdnf install -y ca-certificates && rm -rf /var/cache/yum
 COPY --from=builder /opt/app-root/src/signalfx-prometheus-exporter /
 ENTRYPOINT ["/signalfx-prometheus-exporter"]
+CMD ["serve"]


### PR DESCRIPTION
right now, no command is specified. the serve command is a very meaningful choice for a default

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>