### PR TITLE
tracking last received metric in flow and stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ The `:9091/metrics` endpoint of SignalFX Prometheus exporter yields all metrics 
 
 The `:9091/probe/$label?target=$value` endpoint can be used to filter metrics based on a Prometheus  `$label` with value `$value`, e.g. `http://localhost:9091/probe/instance?target=my_instance`
 
+## Observability
+Obersvability metrics for flow programs and the go runtime are available on observability endpoint `:9090/metrics`.
+
+| Metric name| Metric type | Labels |
+| ---------- | ----------- | ------ |
+| sfxpe_flow_metrics_received_total | Counter | `flow`=&lt;flow program name&gt; <br> `stream`=&lt;stream name&gt; |
+| sfxpe_flow_metrics_failed_total | Counter | `flow`=&lt;flow program name&gt; <br> `stream`=&lt;stream name&gt; |
+| sfxpe_flow_last_received_seconds | Gauge | `flow`=&lt;flow program name&gt; <br> `stream`=&lt;stream name&gt; |
+
+An article that goes into details about the exposed go runtime metrics can be found [here](https://povilasv.me/prometheus-go-metrics/).
+
 ## Known issues
 - no data during warmup phase
 - verify query - publish() must exists at least once

--- a/serve/serve.go
+++ b/serve/serve.go
@@ -21,13 +21,15 @@ import (
 
 var (
 	// sfx metrics state
-	sfxRegistry = prometheus.NewRegistry()
-	sfxCounters = make(map[string]*prometheus.CounterVec)
-	sfxGauges   = make(map[string]*prometheus.GaugeVec)
+	sfxRegistry               = prometheus.NewRegistry()
+	sfxCounters               = make(map[string]*prometheus.CounterVec)
+	sfxGauges                 = make(map[string]*prometheus.GaugeVec)
+	lastMetricInFlowTimestamp = make(map[string]time.Time)
 
 	// self observability
 	flowMetricsReceived *prometheus.CounterVec
 	flowMetricsFailed   *prometheus.CounterVec
+	flowLastReceived    *prometheus.GaugeVec
 )
 
 func CollectoAndServe(configFile string, listenPort int, observabilityPort int, ctx context.Context) {
@@ -56,11 +58,16 @@ func CollectoAndServe(configFile string, listenPort int, observabilityPort int, 
 		Help: "Number of received metrics",
 	}, []string{"flow", "stream"})
 	flowMetricsFailed = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "sfxpe_flow_metrics_failed",
+		Name: "sfxpe_flow_metrics_failed_total",
 		Help: "Number of metrics that failed do process",
+	}, []string{"flow", "stream"})
+	flowLastReceived = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "sfxpe_flow_last_received_seconds",
+		Help: "Timestamp where the last metric was received",
 	}, []string{"flow", "stream"})
 	prometheus.MustRegister(flowMetricsReceived)
 	prometheus.MustRegister(flowMetricsFailed)
+	prometheus.MustRegister(flowLastReceived)
 	obsMux := mux.NewRouter()
 	obsMux.Handle("/metrics", promhttp.Handler())
 	obsServer := &http.Server{Addr: fmt.Sprintf(":%v", observabilityPort), Handler: obsMux}
@@ -131,6 +138,13 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func streamData(sfx config.SignalFxConfig, fp config.FlowProgram) error {
+	// initialize flow metrics
+	for _, mt := range fp.MetricTemplates {
+		flowMetricsReceived.WithLabelValues(fp.Name, mt.Stream)
+		flowMetricsFailed.WithLabelValues(fp.Name, mt.Stream)
+		flowMetricsFailed.WithLabelValues(fp.Name, mt.Stream)
+	}
+
 	client, err := signalflow.NewClient(
 		signalflow.StreamURLForRealm(sfx.Realm),
 		signalflow.AccessToken(sfx.Token),
@@ -157,6 +171,7 @@ func streamData(sfx config.SignalFxConfig, fp config.FlowProgram) error {
 				stream = "default"
 			}
 			flowMetricsReceived.WithLabelValues(fp.Name, stream).Inc()
+			flowLastReceived.WithLabelValues(fp.Name, stream).SetToCurrentTime()
 			mt, err := fp.GetMetricTemplateForStream(stream)
 			if err != nil {
 				// todo log


### PR DESCRIPTION
the last received metric per flow and stream is interesting to track faulty
flow programs. the metric is exposed as timestamp with the name sfxpe_flow_last_received_seconds

additionally, documentation for other exposed metrics was added to the readme

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>