### PR TITLE
explict metric grouping configuration and group readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Since the data delivery mechanism from SignalFX is a stream of metrics, the proc
 
 ## Scraping metric groups
 
-Metrics can also be scraped based on a metric labels. This can be enabled by providing
+Metrics can also be scraped based on a metric label. This can be enabled by providing
 grouping [configuration](docs/configuration.md).
 
 ```yaml
@@ -73,7 +73,7 @@ grouping:
 
 This example enables filtering based on the `instance` label of metrics. A filtered
 scrape on this label can be done via the `:9091/metrics/instance?target=value` endpoint,
-where the `target` query paremter supplies the value to filter on.
+where the `target` query parameter supplies the value to filter on.
 
 The async metric delivery mode of SignalFX makes it necessary to handle situations
 where metrics are yet missing (e.g. cold cache on process startup). The

--- a/README.md
+++ b/README.md
@@ -64,16 +64,7 @@ Since the data delivery mechanism from SignalFX is a stream of metrics, the proc
 Metrics can also be scraped based on a metric label. This can be enabled by providing
 grouping [configuration](docs/configuration.md).
 
-```yaml
-grouping:
-- label: instance
-  groupReadyConditions:
-    minMetrics: 2
-```
-
-This example enables filtering based on the `instance` label of metrics. A filtered
-scrape on this label can be done via the `:9091/metrics/instance?target=value` endpoint,
-where the `target` query parameter supplies the value to filter on.
+Once configured, the endpoint for a group scrape looks like `:9091/probe/$label?target=$value` and returns only metrics with the `$label` set to `$value`.
 
 The async metric delivery mode of SignalFX makes it necessary to handle situations
 where metrics are yet missing (e.g. cold cache on process startup). The
@@ -88,6 +79,20 @@ when less than `minMetrics` metrics would be exposed.
 The `target` parameter to supply a filter for the label makes this scrape
 endpoint compatible with the [`Probe`](https://prometheus-operator.dev/docs/operator/design/#probe)
 CRD from the Prometheus operator.
+
+### Example
+
+The following example enables filtering based on the `instance` label of metrics. A filtered
+scrape on this label can be done via the `:9091/metrics/instance?target=value` endpoint,
+where the `target` query parameter supplies the value to filter on. Additionally, the scrape
+will fail when less than 2 metrics are left after filtering.
+
+```yaml
+grouping:
+- label: instance
+  groupReadyConditions:
+    minMetrics: 2
+```
 
 
 ## Observability

--- a/README.md
+++ b/README.md
@@ -59,10 +59,36 @@ Since the data delivery mechanism from SignalFX is a stream of metrics, the proc
 
 ![architecture](docs/arch.png)
 
-## Blackbox-exporter compatibility
-The `:9091/metrics` endpoint of SignalFX Prometheus exporter yields all metrics that have been processed by SignalFlow programs so far. But the exporter can also be used in a blackbox-exporter compatible way, returning only a set of metrics belonging to a certain scrape target. For blackbox-exporter, a scrape target resembles some resource on the network. For SignalFX Prometheus exporter a scrape target is a way to filter on metric labels. As long as metrics with a common label belong to the same logical unit, such filtering can be used to simulate blackbox-exporter behaviour for target scraping.
+## Scraping metric groups
 
-The `:9091/probe/$label?target=$value` endpoint can be used to filter metrics based on a Prometheus  `$label` with value `$value`, e.g. `http://localhost:9091/probe/instance?target=my_instance`
+Metrics can also be scraped based on a metric labels. This can be enabled by providing
+grouping [configuration](docs/configuration.md).
+
+```yaml
+grouping:
+- label: instance
+  groupReadyConditions:
+    minMetrics: 2
+```
+
+This example enables filtering based on the `instance` label of metrics. A filtered
+scrape on this label can be done via the `:9091/metrics/instance?target=value` endpoint,
+where the `target` query paremter supplies the value to filter on.
+
+The async metric delivery mode of SignalFX makes it necessary to handle situations
+where metrics are yet missing (e.g. cold cache on process startup). The
+`grouping.groupReadyConditions` config section provides options to declare the behaviour
+for such situations, failing a scrape on the `/metric/$label` endpoint when
+the conditions are not satisfied. This will result in the default metric `up`
+on the scraper side to highlight that metrics could not be aquired. Depending
+on the situation, this behaviour might be better than scraping incomplete
+metrics. Right now, the `minMetrics` condition is supported, failing a scrape
+when less than `minMetrics` metrics would be exposed.
+
+The `target` parameter to supply a filter for the label makes this scrape
+endpoint compatible with the [`Probe`](https://prometheus-operator.dev/docs/operator/design/#probe)
+CRD from the Prometheus operator.
+
 
 ## Observability
 Obersvability metrics for flow programs and the go runtime are available on observability endpoint `:9090/metrics`.
@@ -76,5 +102,4 @@ Obersvability metrics for flow programs and the go runtime are available on obse
 An article that goes into details about the exposed go runtime metrics can be found [here](https://povilasv.me/prometheus-go-metrics/).
 
 ## Known issues
-- no data during warmup phase
 - verify query - publish() must exists at least once

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ will fail when less than 2 metrics are left after filtering.
 ```yaml
 grouping:
 - label: instance
-  groupReadyConditions:
+  groupReadyCondition:
     minMetrics: 2
 ```
 

--- a/config/config.go
+++ b/config/config.go
@@ -11,8 +11,7 @@ import (
 )
 
 type GroupReadyConditions struct {
-	MaxAge     string `yaml:"maxAge"`
-	MinMetrics int    `yaml:"minMetrics"`
+	MinMetrics int `yaml:"minMetrics"`
 }
 
 type GroupingConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 type GroupReadyCondition struct {
-	MinMetrics int `yaml:"minMetrics"`
+	MinMetrics uint `yaml:"minMetrics"`
 }
 
 type Grouping struct {
@@ -142,20 +142,23 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-func LoadConfig(file string) (*Config, error) {
-	yamlFile, err := ioutil.ReadFile(file)
-	if err != nil {
-		log.Printf("yamlFile.Get err   #%v ", err)
-		return nil, err
-	}
-
+func LoadConfigFromBytes(configBytes []byte) (*Config, error) {
 	var cfg Config
-	err = yaml.Unmarshal(yamlFile, &cfg)
+	err := yaml.Unmarshal(configBytes, &cfg)
 	if err != nil {
-		log.Fatalf("Unmarshal: %v", err)
+		log.Printf("Unmarshal: %v\n", err)
 		return nil, err
 	}
 
 	cfg.Validate()
 	return &cfg, nil
+}
+
+func LoadConfig(file string) (*Config, error) {
+	configBytes, err := ioutil.ReadFile(file)
+	if err != nil {
+		log.Printf("yamlFile.Get err   #%v ", err)
+		return nil, err
+	}
+	return LoadConfigFromBytes(configBytes)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,16 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type GroupReadyConditions struct {
+	MaxAge     string `yaml:"maxAge"`
+	MinMetrics int    `yaml:"minMetrics"`
+}
+
+type GroupingConfig struct {
+	Label           string
+	ReadyConditions GroupReadyConditions `yaml:"groupReadyConditions"`
+}
+
 type PrometheusMetric struct {
 	Name           string            `yaml:"name"`
 	Stream         string            `yaml:"stream"`
@@ -115,8 +125,9 @@ func (sfx *SignalFxConfig) Validate() error {
 }
 
 type Config struct {
-	Sfx   SignalFxConfig `yaml:"sfx"`
-	Flows []FlowProgram  `yaml:"flows"`
+	Sfx      SignalFxConfig   `yaml:"sfx"`
+	Flows    []FlowProgram    `yaml:"flows"`
+	Grouping []GroupingConfig `yaml:"grouping"`
 }
 
 func (c *Config) Validate() error {

--- a/config/config.go
+++ b/config/config.go
@@ -10,13 +10,13 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-type GroupReadyConditions struct {
+type GroupReadyCondition struct {
 	MinMetrics int `yaml:"minMetrics"`
 }
 
-type GroupingConfig struct {
-	Label           string
-	ReadyConditions GroupReadyConditions `yaml:"groupReadyConditions"`
+type Grouping struct {
+	Label               string
+	GroupReadyCondition GroupReadyCondition `yaml:"groupReadyCondition"`
 }
 
 type PrometheusMetric struct {
@@ -111,12 +111,12 @@ func (fp *FlowProgram) Validate() error {
 	return nil
 }
 
-type SignalFxConfig struct {
+type Sfx struct {
 	Realm string `yaml:"realm"`
 	Token string `yaml:"token"`
 }
 
-func (sfx *SignalFxConfig) Validate() error {
+func (sfx *Sfx) Validate() error {
 	if sfx.Realm == "" {
 		sfx.Realm = "us1"
 	}
@@ -124,9 +124,9 @@ func (sfx *SignalFxConfig) Validate() error {
 }
 
 type Config struct {
-	Sfx      SignalFxConfig   `yaml:"sfx"`
-	Flows    []FlowProgram    `yaml:"flows"`
-	Grouping []GroupingConfig `yaml:"grouping"`
+	Sfx       Sfx           `yaml:"sfx"`
+	Flows     []FlowProgram `yaml:"flows"`
+	Groupings []Grouping    `yaml:"grouping"`
 }
 
 func (c *Config) Validate() error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -45,3 +45,26 @@ func TestGetLabelValue(t *testing.T) {
 	assert.Equal(t, "test", x)
 
 }
+
+func TestMinMetricsNotAUInt(t *testing.T) {
+	configFile := `---
+sfx:
+token: xxx
+flows:
+- name: catchpoint-data
+  query: |
+    data('catchpoint.counterfailedrequests').publish()
+    data('catchpoint.counterrequests').publish()
+  prometheusMetricTemplates:
+  - type: counter
+  labels:
+    instance: '{{ .SignalFxLabels.cp_testname }}'
+grouping:
+- label: instance
+  groupReadyCondition:
+    minMetrics: -1
+`
+	_, err := config.LoadConfigFromBytes([]byte(configFile))
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "`-1` into uint")
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,6 +5,7 @@ The configuration file is written in YAML format and adheres to the schema descr
 Generic placeholders are defined as follows:
 
 * `<string>`: a regular string
+* `<int>`: an integer
 * `<prometheus-label>`: a string following the prometheus label regex `[a-zA-Z_][a-zA-Z0-9_]*`
 * `<go-template>`: a string that contains a go-template
 
@@ -21,6 +22,10 @@ The variables usable in go templates are described in the [SignalFlow primer](si
   # The list of metric flows from SignalFX to process into Prometheus metrics
   flows:
     [ - <flow>, ... ]
+
+  # Optional configuration for scraping based on labels
+  grouping:
+    [ - <grouping>, ...]
 ```
 
 ### Flow
@@ -57,4 +62,16 @@ A Prometheus metric translates a SignalFX metric into a Prometheus metric.
   # Labels for the Prometheus metric
   labels:
     [ <prometheus-label>: <go-template>, ... ]
+```
+
+### Grouping
+Grouping configuration enables scraping metrics based on labels.
+
+```yml
+  # The label that can be used for grouped scrapes
+  label: <prometheus-label>
+  # Conditions that will fail the group scrape when they are not true
+  [ groupReadyConditions: ]
+    # Minimum number of metrics within a group to let the scrape succeed
+    minMetrics: <int>
 ```

--- a/examples/3_metric_grouping.yml
+++ b/examples/3_metric_grouping.yml
@@ -11,5 +11,5 @@ flows:
       instance: '{{ .SignalFxLabels.cp_testname }}'
 grouping:
 - label: instance
-  groupReadyConditions:
+  groupReadyCondition:
     minMetrics: 2

--- a/examples/3_metric_grouping.yml
+++ b/examples/3_metric_grouping.yml
@@ -1,0 +1,15 @@
+sfx:
+  token: xxx
+flows:
+- name: catchpoint-data
+  query: |
+    data('catchpoint.counterfailedrequests').publish()
+    data('catchpoint.counterrequests').publish()
+  prometheusMetricTemplates:
+  - type: counter
+    labels:
+      instance: '{{ .SignalFxLabels.cp_testname }}'
+grouping:
+- label: instance
+  groupReadyConditions:
+    minMetrics: 2

--- a/serve/registry.go
+++ b/serve/registry.go
@@ -1,17 +1,21 @@
 package serve
 
 import (
+	"fmt"
+	"signalfx-prometheus-exporter/config"
+
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 )
 
 type FilteringRegistry struct {
 	Registry    prometheus.Gatherer
-	FilterLabel string
+	Grouping    config.GroupingConfig
 	FilterValue string
 }
 
 func (fr *FilteringRegistry) Gather() ([]*dto.MetricFamily, error) {
+	metricCount := 0
 	mfs, err := fr.Registry.Gather()
 	if err != nil {
 		return nil, err
@@ -22,8 +26,9 @@ func (fr *FilteringRegistry) Gather() ([]*dto.MetricFamily, error) {
 		metrics := []*dto.Metric{}
 		for _, m := range mf.GetMetric() {
 			for _, l := range m.GetLabel() {
-				if *l.Name == fr.FilterLabel && *l.Value == fr.FilterValue {
+				if *l.Name == fr.Grouping.Label && *l.Value == fr.FilterValue {
 					metrics = append(metrics, m)
+					metricCount++
 					break
 				}
 			}
@@ -38,5 +43,9 @@ func (fr *FilteringRegistry) Gather() ([]*dto.MetricFamily, error) {
 		}
 	}
 
-	return filteredMfs, nil
+	if metricCount >= fr.Grouping.ReadyConditions.MinMetrics {
+		return filteredMfs, nil
+	} else {
+		return nil, fmt.Errorf("Not enough metrics in group. minMetrics = %d", fr.Grouping.ReadyConditions.MinMetrics)
+	}
 }

--- a/serve/registry.go
+++ b/serve/registry.go
@@ -10,7 +10,7 @@ import (
 
 type FilteringRegistry struct {
 	Registry    prometheus.Gatherer
-	Grouping    config.GroupingConfig
+	Grouping    config.Grouping
 	FilterValue string
 }
 
@@ -43,9 +43,9 @@ func (fr *FilteringRegistry) Gather() ([]*dto.MetricFamily, error) {
 		}
 	}
 
-	if metricCount >= fr.Grouping.ReadyConditions.MinMetrics {
+	if metricCount >= fr.Grouping.GroupReadyCondition.MinMetrics {
 		return filteredMfs, nil
 	} else {
-		return nil, fmt.Errorf("Not enough metrics in group. minMetrics = %d", fr.Grouping.ReadyConditions.MinMetrics)
+		return nil, fmt.Errorf("Not enough metrics in group. minMetrics = %d", fr.Grouping.GroupReadyCondition.MinMetrics)
 	}
 }

--- a/serve/registry.go
+++ b/serve/registry.go
@@ -15,7 +15,7 @@ type FilteringRegistry struct {
 }
 
 func (fr *FilteringRegistry) Gather() ([]*dto.MetricFamily, error) {
-	metricCount := 0
+	var metricCount uint = 0
 	mfs, err := fr.Registry.Gather()
 	if err != nil {
 		return nil, err

--- a/serve/registry_test.go
+++ b/serve/registry_test.go
@@ -17,9 +17,9 @@ var (
 func setupRegistry(minMetrics int) (*serve.FilteringRegistry, *prometheus.Registry) {
 	registry := prometheus.NewRegistry()
 
-	grouping := config.GroupingConfig{
+	grouping := config.Grouping{
 		Label: FilterLabel,
-		ReadyConditions: config.GroupReadyConditions{
+		GroupReadyCondition: config.GroupReadyCondition{
 			MinMetrics: minMetrics,
 		},
 	}

--- a/serve/registry_test.go
+++ b/serve/registry_test.go
@@ -14,7 +14,7 @@ var (
 	FilterValue = "value"
 )
 
-func setupRegistry(minMetrics int) (*serve.FilteringRegistry, *prometheus.Registry) {
+func setupRegistry(minMetrics uint) (*serve.FilteringRegistry, *prometheus.Registry) {
 	registry := prometheus.NewRegistry()
 
 	grouping := config.Grouping{
@@ -37,7 +37,7 @@ func TestMinimumMetricsSupplied(t *testing.T) {
 	/* test that the filtering registry is not complaining
 	   when the minimum required metrics remain after filtering */
 
-	minMetrics := 2
+	var minMetrics uint = 2
 	fr, registry := setupRegistry(minMetrics)
 
 	gaugeWithMatchingLabel := prometheus.NewGaugeVec(
@@ -59,9 +59,9 @@ func TestMinimumMetricsSupplied(t *testing.T) {
 	assert.NotNil(t, metricFamilies)
 	assert.NotEmpty(t, metricFamilies)
 
-	metricCounter := 0
+	var metricCounter uint = 0
 	for _, mf := range metricFamilies {
-		metricCounter += len(mf.Metric)
+		metricCounter += uint(len(mf.Metric))
 	}
 	assert.GreaterOrEqual(t, metricCounter, minMetrics)
 }
@@ -70,7 +70,7 @@ func TestTooFewSupplied(t *testing.T) {
 	/* test that the filtering registry raises and error
 	   when less metrics remain as demanded after filtering */
 
-	minMetrics := 2
+	var minMetrics uint = 2
 	fr, registry := setupRegistry(minMetrics)
 
 	gaugeWithMatchingLabel := prometheus.NewGaugeVec(

--- a/serve/registry_test.go
+++ b/serve/registry_test.go
@@ -1,0 +1,92 @@
+package serve_test
+
+import (
+	"signalfx-prometheus-exporter/config"
+	"signalfx-prometheus-exporter/serve"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	FilterLabel = "label"
+	FilterValue = "value"
+)
+
+func setupRegistry(minMetrics int) (*serve.FilteringRegistry, *prometheus.Registry) {
+	registry := prometheus.NewRegistry()
+
+	grouping := config.GroupingConfig{
+		Label: FilterLabel,
+		ReadyConditions: config.GroupReadyConditions{
+			MinMetrics: minMetrics,
+		},
+	}
+
+	fr := &serve.FilteringRegistry{
+		Grouping:    grouping,
+		Registry:    registry,
+		FilterValue: FilterValue,
+	}
+
+	return fr, registry
+}
+
+func TestMinimumMetricsSupplied(t *testing.T) {
+	/* test that the filtering registry is not complaining
+	   when the minimum required metrics remain after filtering */
+
+	minMetrics := 2
+	fr, registry := setupRegistry(minMetrics)
+
+	gaugeWithMatchingLabel := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "some_gauge"},
+		[]string{FilterLabel},
+	)
+	registry.MustRegister(gaugeWithMatchingLabel)
+	counterWithMatchingLabel := prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "some_counter"},
+		[]string{FilterLabel},
+	)
+	registry.MustRegister(counterWithMatchingLabel)
+
+	gaugeWithMatchingLabel.WithLabelValues(FilterValue).Set(0)
+	counterWithMatchingLabel.WithLabelValues(FilterValue).Add(1)
+
+	metricFamilies, err := fr.Gather()
+	assert.Nil(t, err)
+	assert.NotNil(t, metricFamilies)
+	assert.NotEmpty(t, metricFamilies)
+
+	metricCounter := 0
+	for _, mf := range metricFamilies {
+		metricCounter += len(mf.Metric)
+	}
+	assert.GreaterOrEqual(t, metricCounter, minMetrics)
+}
+
+func TestTooFewSupplied(t *testing.T) {
+	/* test that the filtering registry raises and error
+	   when less metrics remain as demanded after filtering */
+
+	minMetrics := 2
+	fr, registry := setupRegistry(minMetrics)
+
+	gaugeWithMatchingLabel := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "some_gauge"},
+		[]string{FilterLabel},
+	)
+	registry.MustRegister(gaugeWithMatchingLabel)
+	counterWithMatchingLabel := prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "some_counter"},
+		[]string{FilterLabel},
+	)
+	registry.MustRegister(counterWithMatchingLabel)
+
+	gaugeWithMatchingLabel.WithLabelValues(FilterValue).Set(0)
+	counterWithMatchingLabel.WithLabelValues("other_value").Add(1)
+
+	_, err := fr.Gather()
+	assert.Error(t, err)
+}

--- a/serve/serve.go
+++ b/serve/serve.go
@@ -82,7 +82,7 @@ func CollectoAndServe(configFile string, listenPort int, observabilityPort int, 
 	mux.HandleFunc("/ready", readinessHandler)
 	mux.HandleFunc("/healthy", livenessHandler)
 	mux.HandleFunc("/metrics", metricsHandler)
-	for _, g := range cfg.Grouping {
+	for _, g := range cfg.Groupings {
 		mux.HandleFunc(fmt.Sprintf("/metrics/%s", g.Label), func(rw http.ResponseWriter, r *http.Request) {
 			probeHandler(g, rw, r)
 		})
@@ -117,7 +117,7 @@ func livenessHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func probeHandler(grouping config.GroupingConfig, w http.ResponseWriter, r *http.Request) {
+func probeHandler(grouping config.Grouping, w http.ResponseWriter, r *http.Request) {
 	// blackbox exporter compatible scrape handler
 	ctx, cancel := context.WithTimeout(r.Context(), time.Duration(5*float64(time.Second)))
 	defer cancel()
@@ -147,7 +147,7 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 	h.ServeHTTP(w, r)
 }
 
-func streamData(sfx config.SignalFxConfig, fp config.FlowProgram) error {
+func streamData(sfx config.Sfx, fp config.FlowProgram) error {
 	// initialize flow metrics
 	for _, mt := range fp.MetricTemplates {
 		flowMetricsReceived.WithLabelValues(fp.Name, mt.Stream)

--- a/serve/serve.go
+++ b/serve/serve.go
@@ -51,7 +51,7 @@ func CollectoAndServe(configFile string, listenPort int, observabilityPort int, 
 		})
 	}
 
-	// start observability server
+	// configure and start observability server
 	flowMetricsReceived = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "sfxpe_flow_metrics_received_total",
 		Help: "Number of received metrics",
@@ -77,12 +77,16 @@ func CollectoAndServe(configFile string, listenPort int, observabilityPort int, 
 	}()
 	log.Printf("Observability server listening on port %v\n", observabilityPort)
 
-	// start probe server
+	// configure and start scrape server
 	mux := mux.NewRouter()
 	mux.HandleFunc("/ready", readinessHandler)
 	mux.HandleFunc("/healthy", livenessHandler)
 	mux.HandleFunc("/metrics", metricsHandler)
-	mux.HandleFunc("/probe/{target}", probeHandler)
+	for _, g := range cfg.Grouping {
+		mux.HandleFunc(fmt.Sprintf("/metrics/%s", g.Label), func(rw http.ResponseWriter, r *http.Request) {
+			probeHandler(g, rw, r)
+		})
+	}
 	server := &http.Server{Addr: fmt.Sprintf(":%v", listenPort), Handler: mux}
 	go func() {
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
@@ -113,28 +117,25 @@ func livenessHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func probeHandler(w http.ResponseWriter, r *http.Request) {
+func probeHandler(grouping config.GroupingConfig, w http.ResponseWriter, r *http.Request) {
 	// blackbox exporter compatible scrape handler
 	ctx, cancel := context.WithTimeout(r.Context(), time.Duration(5*float64(time.Second)))
 	defer cancel()
 	r = r.WithContext(ctx)
 
-	vars := mux.Vars(r)
-	targetLabel, ok := vars["target"]
-	if ok && targetLabel != "" {
-		targetValue, ok := r.URL.Query()["target"]
-		if ok && len(targetValue) > 0 {
-			metricGatherer := &FilteringRegistry{
-				Registry:    sfxRegistry,
-				FilterLabel: targetLabel,
-				FilterValue: targetValue[0],
-			}
-			h := promhttp.HandlerFor(metricGatherer, promhttp.HandlerOpts{})
-			h.ServeHTTP(w, r)
-			return
+	targetValue, ok := r.URL.Query()["target"]
+	if ok && len(targetValue) > 0 {
+		metricGatherer := &FilteringRegistry{
+			Registry:    sfxRegistry,
+			Grouping:    grouping,
+			FilterValue: targetValue[0],
 		}
+		h := promhttp.HandlerFor(metricGatherer, promhttp.HandlerOpts{})
+		h.ServeHTTP(w, r)
+		return
+	} else {
+		w.WriteHeader(http.StatusBadRequest)
 	}
-	w.WriteHeader(http.StatusBadRequest)
 }
 
 func metricsHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
introduce configuration options for metric scraping based on labels to improve
blackbox-exporter compatibility mode. grouping options are now explicit and
include options to define when a group of metrics is ready for scraping, e.g.
number of metrics available within a group.

the async metric delivery mode of signalfx makes it necessary to handle situations
when metrics are yet missing (e.g. cold cache on process startup). the `groupReadyConditions` config
section provides options to declare the behaviour for such situations, failing a
scrape on the `/metric/$label_name` endpoint in situations when the conditions
are not satisfied. this will result in the default metric `up` on the scraper side
to highlight that metrics could not be aquired. depending on the situation, this
behaviour might be better than scraping incomplete or outdated metrics.

the following configuration enables filtered scraping based on the
specified label `label`. also, at least 2 metrics must be present after filtering
on the label. otherwise the scrape endpoint will fail with a descriptive error.

```yaml
grouping:
- label: label
  groupReadyConditions:
    minMetrics: 2
```

for filtering on the provided label, the url parameter `target` is used. this
provides compatibility with blackbox-exporter and enables the use of the `Probe`
CRD that comes with the Prometheus operator.

a valid scrape URL looks like this:

`:9091/metrics/label?target=value`

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>