### PR TITLE
allow a relative start date for data received by a stream

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,8 +6,9 @@ import (
 	"io/ioutil"
 	"log"
 	"text/template"
+	"time"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type GroupReadyCondition struct {
@@ -78,6 +79,7 @@ func (pm *PrometheusMetric) GetLabelValue(labelName string, data NameTemplateVar
 type FlowProgram struct {
 	Name              string             `yaml:"name"`
 	Query             string             `yaml:"query"`
+	HistoricalData    time.Duration      `yaml:"historicalData"`
 	MetricTemplates   []PrometheusMetric `yaml:"prometheusMetricTemplates"`
 	templatesByStream map[string]PrometheusMetric
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,6 +3,7 @@ package config_test
 import (
 	"signalfx-prometheus-exporter/config"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -67,4 +68,27 @@ grouping:
 	_, err := config.LoadConfigFromBytes([]byte(configFile))
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "`-1` into uint")
+}
+
+func TestMinHistoricalData(t *testing.T) {
+	configFile := `---
+sfx:
+token: xxx
+flows:
+- name: catchpoint-data
+  historicalData: 99s
+  query: |
+    data('catchpoint.counterfailedrequests').publish()
+    data('catchpoint.counterrequests').publish()
+  prometheusMetricTemplates:
+  - type: counter
+  labels:
+    instance: '{{ .SignalFxLabels.cp_testname }}'
+`
+	cfg, err := config.LoadConfigFromBytes([]byte(configFile))
+	assert.Nil(t, err)
+	assert.NotNil(t, cfg)
+
+	ninty_nine, _ := time.ParseDuration("99s")
+	assert.Equal(t, cfg.Flows[0].HistoricalData, ninty_nine)
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,7 @@ Generic placeholders are defined as follows:
 * `<int>`: an integer
 * `<prometheus-label>`: a string following the prometheus label regex `[a-zA-Z_][a-zA-Z0-9_]*`
 * `<go-template>`: a string that contains a go-template
+* `<duration-string>`: decimal numbers, each with optional fraction and a unit suffix (s, m, h), e.g. 60s
 
 The variables usable in go templates are described in the [SignalFlow primer](signalflow.md).
 
@@ -36,6 +37,10 @@ A flow describes how metrics are queried from SignalFX and processed into Promet
 
   # The SignalFlow program to query data from SignalFX
   query: <string>
+
+  # The amount of historical data that will be received when a flow program starts.
+  # Can be used to get data quicker for scraping.
+  [ historicalData: <duration-string> | default = 0 ]
 
   # A collection of templates to turn SignalFlow query results into Prometheus metrics
   prometheusMetricTemplate:

--- a/examples/3_metric_grouping.yml
+++ b/examples/3_metric_grouping.yml
@@ -2,6 +2,7 @@ sfx:
   token: xxx
 flows:
 - name: catchpoint-data
+  historicalData: 60s
   query: |
     data('catchpoint.counterfailedrequests').publish()
     data('catchpoint.counterrequests').publish()

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/signalfx/signalfx-go v1.8.7
 	github.com/spf13/cobra v1.3.0
-	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/go.sum
+++ b/go.sum
@@ -837,7 +837,6 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=

--- a/serve/serve.go
+++ b/serve/serve.go
@@ -165,6 +165,7 @@ func streamData(sfx config.Sfx, fp config.FlowProgram) error {
 
 	comp, err := client.Execute(&signalflow.ExecuteRequest{
 		Program: fp.Query,
+		Start:   time.Now().Add(fp.HistoricalData * -1),
 	})
 	if err != nil {
 		return fmt.Errorf("SignalFlow program for %s is invalid - %+s", fp.Name, err)


### PR DESCRIPTION
with the `historicalData` duration string, the amount of historical
data that will be received on stream start can be controlled.

this allows for quicker metric cache filling for metrics. e.g. by
setting historicalData to 60s, on stream start metrics that are up to
60s old, will immediately be available on the stream and thereforce
are immediately available for scraping.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>